### PR TITLE
Added smarter seek power

### DIFF
--- a/simple_bot.py
+++ b/simple_bot.py
@@ -34,7 +34,6 @@ class SimpleBot:
         else:
             self.deck.draw_7()
 
-
     #a basic step towards more complicated play-at the moment it just handles diplo seal stupidly.
     def play_turn(self):
         self.deck.draw()
@@ -43,7 +42,7 @@ class SimpleBot:
             card = self.deck.gamestate.hand[idx]
             #check if we aquire influence when playing it
             if card.acquire_influence(self.deck.gamestate):
-                max_key = self.distance_from_target()
+                (max_key, total_difference) = self.distance_from_target()
                 self.deck.play_card('Diplomatic Seal', influence=max_key)
         else:
             #play a random power for now
@@ -52,33 +51,37 @@ class SimpleBot:
                 card = self.deck.gamestate.hand[idx]
                 self.deck.play_card(card.name)
         if 'Seek Power' in [x.name for x in self.deck.gamestate.hand]:
-            max_key = self.distance_from_target(seek=True)
-            self.deck.play_seek(max_key)
-            self.deck.play_card('Seek Power')
+            (max_key, total_difference) = self.distance_from_target(seek=True)
+            if total_difference <= 1:
+                self.deck.play_seek(max_key)
+                self.deck.play_card('Seek Power')
         self.power_drawn_per_turn.append(dict(self.deck.gamestate.drawn_power))
 
 
 
     #a simple method of choosing which influence is missing
     def distance_from_target(self, seek=False):
-        max_difference = -1000     
+        max_difference = -1000
+        total_difference= 0
         max_key = ''
         for key in self.target:
             if seek:
                 if not [x for x in self.deck.gamestate.power if x.influence == {key:1} and 'Sigil' in x.name]:
                     continue
             dif = self.target[key] - self.deck.gamestate.drawn_power[key]
+            if (dif > 0):
+                total_difference += dif
             if dif > max_difference:
                 max_difference = dif
                 max_key = key
-        return max_key
+        return (max_key, total_difference)
 
 
-num_runs = 10000
+num_runs = 100000
 turns_per_run = 10
 runs = []
 for i in range(num_runs):
-    bot = SimpleBot('decklists/manus_haunted.txt', draw_method='mulligan', target = {'F':2, 'P':1, 'S':2})
+    bot = SimpleBot('decklists/wind_herald_seek.txt', draw_method='mulligan', target = {'F':1, 'P':2, 'S':2})
     [bot.play_turn() for x in range(turns_per_run)]
     power_per_turn = bot.power_drawn_per_turn
     if len(runs) == 0:
@@ -86,7 +89,7 @@ for i in range(num_runs):
     else:
         [x.append(y) for x,y in zip(runs, power_per_turn)]
 
-statistics = calculate_statistics(runs, num_runs, target = {'F':2, 'S':2, 'P':1, 'total': 4})
+statistics = calculate_statistics(runs, num_runs, target = {'F':1, 'S':2, 'P':2, 'total': 6})
 
 print()
 for s in statistics:


### PR DESCRIPTION
Added a slightly smarter version of the seek power code. It now waits until only one influence is needed and specifically fetches that. Further improvement would come if the number of missing influence waited for was tied to number of seek powers in hand, but I couldn't figure out a quick way to do that. 
